### PR TITLE
Update InterpellerGraphView after updates to Phabricator HEAD

### DIFF
--- a/src/interpeller/views/InterpellerGraphView.php
+++ b/src/interpeller/views/InterpellerGraphView.php
@@ -63,7 +63,7 @@ EOT;
 		$counter = 0;
 		$tasks = array();
 
-		Javelin::initBehavior('phabricator-hovercards');
+		Javelin::initBehavior('phui-hovercards');
 
 		foreach ( $this->tasks as $task ) {
 			$phid = $task->getPHID();


### PR DESCRIPTION
In Phabricator HEAD, Javelin's phabricator-hovercards was renamed to phui-hovercards; update InterpellerGraphView to reflect this.
