### PR TITLE
Fix call of removed function in Phabricator D16439.

### DIFF
--- a/src/interpeller/controller/InterpellerGraphController.php
+++ b/src/interpeller/controller/InterpellerGraphController.php
@@ -58,14 +58,9 @@ final class InterpellerGraphController extends InterpellerBaseController {
 		$graph_panel->setViewer( $user );
 		$graph_panel->setQueries( $saved_queries );
 
-		return $this->buildApplicationPage(
-			array(
-				$this->buildApplicationCrumbs(),
-				$graph_panel
-			),
-			array(
-				'title' => pht( 'Interpeller' ),
-			)
-		);
+		$page = $this->newPage();
+		$page->setTitle(pht('Interpeller'));
+		$page->appendChild($graph_panel);
+		return $page->produceAphrontResponse();
 	}
 }


### PR DESCRIPTION
Make Interpeller compatible with Phabricator after https://secure.phabricator.com/rP2201c65eb73fb99b8625bea45c273d262f2c289f.

I also removed the application crumbs, because they would always just display "Interpeller".
